### PR TITLE
CRD 생성 오류 수정

### DIFF
--- a/helm2yaml/applib/helm.py
+++ b/helm2yaml/applib/helm.py
@@ -108,6 +108,14 @@ class Helm:
     os.system(splitcmd)
     os.system('rm {0}{1}'.format(target,genfile))
 
+    isCrd=self.name.endswith('-crds')
+    if isCrd:
+      for entry in os.scandir(target):
+        if entry.is_file():
+          splitcmd = "awk '{f=\""+target+"/"+entry.name+"-\" NR; print $0 > f}' RS='' "+target+"/"+entry.name
+          os.system(splitcmd)
+          os.system('rm {0}{1}'.format(target,entry.name))
+
     # Rename yaml to "KIND_RESOURCENAME.yaml"
     if verbose > 0:
       print('(DEBUG) rename resource yaml files')


### PR DESCRIPTION
https://github.com/openinfradev/helm2yaml/pull/10 내용을 기반으로 작업을 했기 때문에 해당 PR 반영 후 재작업 필요합니다.

tigera-operator (calico)의 경우 'helm show crds' 명령어의 결과에서 각 crd가 '---'로 구분되지 않고 빈줄로 구분되는 문제가 있어 이를 수정합니다.